### PR TITLE
use render props for home route

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -116,7 +116,7 @@ export default class App extends React.Component {
         <Router>
         <main>
           <FullNavbar signout={this.signOutUser} user={this.state.user} signin={this.signInUser}/>
-          <Route exact path="/" component={ () => <Home user={this.state.user} />} />
+          <Route exact path="/" render={(props) => <Home {...props} user={this.state.user} />} />
          {/* <Route path="/login" component={() => <Login user={this.state.user} signin={this.signInUser}  />} /> */}
           <Route path="/welcome" component={() => <WelcomePage user={this.state.user} projects={this.state.myProjects} getProjects={this.getProjectsFromFirebase} />} />
         </main>


### PR DESCRIPTION
So I am not sure if this will work, but I thought using the [render prop design pattern](https://tylermcginnis.com/react-router-pass-props-to-components/) for React Router may be worth a shot.

I used the [React Dev Tools Chrome Extension](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi) to see that the <Home /> component is not being rendered on the page at all.  I suspect it is because of React Router not being able to either detect the current page, or build the Home component.  Let's try this and see if anything changes?!