### PR TITLE
Update node version to 10

### DIFF
--- a/cloud-functions-sendmail/functions/package.json
+++ b/cloud-functions-sendmail/functions/package.json
@@ -9,7 +9,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "8"
+    "node": "10"
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
There is an error in the Firebase Cloud Functions Console that the Node version 8 is deprecated :(
![image](https://user-images.githubusercontent.com/21069635/95002924-f3e86f00-059e-11eb-839a-4aebe410a51e.png)

This upgrades it to 10, per the [Firebase docs](https://firebase.google.com/docs/functions/manage-functions#set_nodejs_version).  I am concerned that this may not work, because the docs say:
>The version 12 and 10 runtimes require you to enable the Blaze pay-as-you-go billing plan for your Firebase project.

That plan requires a credit card I am pretty sure... currently the project is on the Spark (free) plan.

But since it's broken anyway, let's try upgrading this way to see what happens?